### PR TITLE
We're on NPM!

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 <!-- Badges -->
 <p align="center">
-    <a href="https://macosnotif.js.org/">
-        <img src="https://img.shields.io/github/package-json/v/MattIPv4/macOSNotifJS.svg?style=flat-square&colorB=007aff" alt="Package Version">
+    <a href="https://npmjs.com/package/macosnotif">
+        <img src="https://img.shields.io/npm/v/macosnotif.svg?style=flat-square&colorB=007aff" alt="NPM Package Version">
     </a>
     <a href="https://github.com/MattIPv4/macOSNotifJS/tree/master/LICENSE">
         <img src="https://img.shields.io/badge/license-AGPL--3.0-007aff.svg?style=flat-square" alt="License">
@@ -40,7 +40,8 @@
 <!-- Content -->
 ## Installation, Usage and About
 
-Please see the full information about how to use the plugin and what it does on the website: **[macosnotif.js.org](https://macosnotif.js.org/).**
+**Please use [the macOSNotifJS website](https://macosnotif.js.org/) for information on installation & usage:\
+    [macosnotif.js.org](https://macosnotif.js.org/)**
 
 Huge thanks to [@Spring3](https://github.com/Spring3) for refactoring this whole project from my original mess into a functional, distributable plugin.
 
@@ -75,6 +76,7 @@ Need support with this project, have found an issue or want to chat with others 
 Not found what you need here?
 * If you have an issue, please create a GitHub issue here to report the situation, include as much detail as you can!
 * _or,_ You can join our Slack workspace to discuss any issue, to get support for the project or to chat with contributors and myself:
+
 <a href="http://slack.mattcowley.co.uk/" target="_blank">
     <img src="https://img.shields.io/badge/slack-MattIPv4-blue.svg?logo=slack&logoWidth=30&logoColor=blue&style=popout-square" alt="Slack" height="60">
 </a>

--- a/index.html
+++ b/index.html
@@ -285,9 +285,9 @@
     </small>
     <br/>
     <small>
-        <a href="https://macosnotif.js.org/">
-            <img src="https://img.shields.io/badge/package-v0.1.0-007aff.svg?style=flat-square"
-                 alt="Package Version">
+        <a href="https://npmjs.com/package/macosnotif">
+            <img src="https://img.shields.io/npm/v/macosnotif.svg?style=flat-square&colorB=007aff"
+                 alt="NPM Package Version">
         </a>
         <a href="https://github.com/MattIPv4/macOSNotifJS/tree/master/LICENSE">
             <img src="https://img.shields.io/badge/license-AGPL--3.0-007aff.svg?style=flat-square" alt="License">
@@ -326,15 +326,19 @@
 </blockquote>
 
 <h3><a id="installation" data-section-link></a> Installation:</h3>
-<p>To use the plugin, copy the <code>dist</code> folder from the <a href="https://github.com/MattIPv4/macOSNotifJS">
-    macOSNotifJS GitHub repository</a> to your website.</p>
+
+<p>For the easiest use, you can simply install the plugin through NPM:</p>
+<pre class="code">npm i macosnotif</pre>
+
+<p>Or, you can manually install by copying the <code>dist</code> folder from the
+    <a href="https://github.com/MattIPv4/macOSNotifJS">macOSNotifJS GitHub repository</a> to your website.</p>
 
 <p>To then have the plugin available on a page, in your head tag have the following to load the notification
     styling:</p>
-<pre class="code">&lt;link href="dist/macOSNotif.min.css" rel="stylesheet"/&gt;</pre>
+<pre class="code">&lt;link href="path/to/dist/macOSNotif.min.css" rel="stylesheet"/&gt;</pre>
 
 <p>At the bottom of your body, you then need to have the following to load the notification script:</p>
-<pre class="code">&lt;script src="dist/macOSNotif.min.js"&gt;&lt;/script&gt;</pre>
+<pre class="code">&lt;script src="path/to/dist/macOSNotif.min.js"&gt;&lt;/script&gt;</pre>
 
 <h3><a id="usage" data-section-link></a> Usage:</h3>
 <p>To get started, simply call the function <code>macOSNotif</code>.

--- a/index.tpl
+++ b/index.tpl
@@ -285,9 +285,9 @@
     </small>
     <br/>
     <small>
-        <a href="https://macosnotif.js.org/">
-            <img src="https://img.shields.io/badge/package-<%= htmlWebpackPlugin.options.meta.version.replace(/-/g, '--') %>-007aff.svg?style=flat-square"
-                 alt="Package Version">
+        <a href="https://npmjs.com/package/macosnotif">
+            <img src="https://img.shields.io/npm/v/macosnotif.svg?style=flat-square&colorB=007aff"
+                 alt="NPM Package Version">
         </a>
         <a href="https://github.com/MattIPv4/macOSNotifJS/tree/master/LICENSE">
             <img src="https://img.shields.io/badge/license-AGPL--3.0-007aff.svg?style=flat-square" alt="License">
@@ -326,15 +326,19 @@
 </blockquote>
 
 <h3><a id="installation" data-section-link></a> Installation:</h3>
-<p>To use the plugin, copy the <code>dist</code> folder from the <a href="https://github.com/MattIPv4/macOSNotifJS">
-    macOSNotifJS GitHub repository</a> to your website.</p>
+
+<p>For the easiest use, you can simply install the plugin through NPM:</p>
+<pre class="code">npm i macosnotif</pre>
+
+<p>Or, you can manually install by copying the <code>dist</code> folder from the
+    <a href="https://github.com/MattIPv4/macOSNotifJS">macOSNotifJS GitHub repository</a> to your website.</p>
 
 <p>To then have the plugin available on a page, in your head tag have the following to load the notification
     styling:</p>
-<pre class="code"><% for (var css in htmlWebpackPlugin.files.css) { %>&lt;link href="<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet"/&gt;<% } %></pre>
+<pre class="code"><% for (var css in htmlWebpackPlugin.files.css) { %>&lt;link href="path/to/<%= htmlWebpackPlugin.files.css[css] %>" rel="stylesheet"/&gt;<% } %></pre>
 
 <p>At the bottom of your body, you then need to have the following to load the notification script:</p>
-<pre class="code"><% for (var chunk in htmlWebpackPlugin.files.chunks) { %>&lt;script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"&gt;&lt;/script&gt;<% } %></pre>
+<pre class="code"><% for (var chunk in htmlWebpackPlugin.files.chunks) { %>&lt;script src="path/to/<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"&gt;&lt;/script&gt;<% } %></pre>
 
 <h3><a id="usage" data-section-link></a> Usage:</h3>
 <p>To get started, simply call the function <code>macOSNotif</code>.


### PR DESCRIPTION
## Proposed changes
 - macOSNotifJS is now on NPM! Fixes #16 
 - Add install via NPM command to website, make copying for GH "manual" installation.
 - Replace manual/GH version badge with NPM version badge.
 - Minor edits to README.

## Additional comments
N/A

## Screenshots
N/A
